### PR TITLE
Added var T, lstsq(), zeros(like:), ones(like:), vstack(), hstack()

### DIFF
--- a/Example/LASwift.xcodeproj/project.pbxproj
+++ b/Example/LASwift.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		36EF117C21E9704600B11E01 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36EF117B21E9704600B11E01 /* Foundation.framework */; };
 		36EF117D21E9704D00B11E01 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3611B64221E96E08004E0EF8 /* Accelerate.framework */; };
 		36EF117F21E9705600B11E01 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36EF117E21E9705600B11E01 /* Foundation.framework */; };
+		8BC160942517B84C00E240A3 /* MatrixLeastSquare.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC160932517B84C00E240A3 /* MatrixLeastSquare.swift */; };
 		B1EC68B8EA0F226DEEFAE493 /* Pods_LASwift_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3EF3DBBB6EE48D4BEE9D991 /* Pods_LASwift_watchOS.framework */; };
 		FA4AC4081E5E3EF000D5F51F /* VectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4AC4071E5E3EF000D5F51F /* VectorTests.swift */; };
 		FA4AC40E1E6614EC00D5F51F /* MatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4AC40D1E6614EC00D5F51F /* MatrixTests.swift */; };
@@ -127,6 +128,7 @@
 		7AA417EDFA0CA2E0992CCB12 /* Pods_LASwift_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LASwift_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		87C7C07F6C2C3A1C56A4F776 /* Pods_LASwift_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LASwift_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8982C2AF1B7A836D1583B9D4 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		8BC160932517B84C00E240A3 /* MatrixLeastSquare.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatrixLeastSquare.swift; sourceTree = "<group>"; };
 		8C2FD693A9DA150F043CE3C2 /* Pods-LASwift-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LASwift-macOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-LASwift-macOS/Pods-LASwift-macOS.release.xcconfig"; sourceTree = "<group>"; };
 		AA60353EB7DC503309D0D1CB /* Pods-LASwift-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LASwift-tvOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-LASwift-tvOS/Pods-LASwift-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		D3EF3DBBB6EE48D4BEE9D991 /* Pods_LASwift_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LASwift_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -229,6 +231,7 @@
 		3611B5B921E96CD1004E0EF8 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				8BC160932517B84C00E240A3 /* MatrixLeastSquare.swift */,
 				3611B5BA21E96CD1004E0EF8 /* Random.swift */,
 				3611B5BB21E96CD1004E0EF8 /* VectorStatistics.swift */,
 				3611B5BC21E96CD1004E0EF8 /* VectorArithmetic.swift */,
@@ -783,6 +786,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA4AC4081E5E3EF000D5F51F /* VectorTests.swift in Sources */,
+				8BC160942517B84C00E240A3 /* MatrixLeastSquare.swift in Sources */,
 				FA4AC40E1E6614EC00D5F51F /* MatrixTests.swift in Sources */,
 				FAD2257E1E7925C40012219D /* PerformanceTests.swift in Sources */,
 			);

--- a/Example/Tests/MatrixTests.swift
+++ b/Example/Tests/MatrixTests.swift
@@ -17,33 +17,38 @@ class MatrixSpec: QuickSpec {
         describe("Matrix construction tests") {
             let count = 10
             
-            let m1 = ones(count, count)
+            let m1 = ones(count, count+1)
             
             it("ones matrix has correct dimensions") {
                 expect(m1.rows) == count
-                expect(m1.cols) == count
+                expect(m1.cols) == count+1
             }
             
             it("ones matrix all ones") {
-                for (i, j) in zip(0..<count, 0..<count) {
-                    expect(m1[i, j]).to(beCloseTo(1.0))
+                for i in 0..<count {
+                    for j in 0..<count+1 {
+                        expect(m1[i, j]).to(beCloseTo(1.0))
+                    }
                 }
             }
             
-            let m2 = zeros(count, count)
+            let m2 = zeros(count, count+1)
             
             it("zeros matrix has correct dimensions") {
                 expect(m2.rows) == count
-                expect(m2.cols) == count
+                expect(m2.cols) == count+1
             }
             
             it("zeros matrix all zeros") {
-                for (i, j) in zip(0..<count, 0..<count) {
-                    expect(m2[i, j]).to(beCloseTo(0.0))
+                for i in 0..<count {
+                    for j in 0..<count+1 {
+                        expect(m2[i, j]).to(beCloseTo(0.0))
+                    }
                 }
+
             }
             
-            let m3 = zeros(count, count)
+            let m3 = zeros(count, count+1)
             
             it("zeros vectors are equal") {
                 expect(m3) == m2
@@ -53,6 +58,18 @@ class MatrixSpec: QuickSpec {
                 expect(m2) != m1
             }
             
+            let ones_like_m3 = ones(like: m3)   // input is zeros(count, count+1)
+            
+            it("ones like are equal") {
+                expect(ones_like_m3) == m1      // test against ones(count, count+1)
+            }
+            
+            let zeros_like_m1 = zeros(like: m1) // input is ones(count, count+1)
+            
+            it("zeros like are equal") {
+                expect(zeros_like_m1) == m3     // test against zeros(count, count+1)
+            }
+
             let m4 = eye(count, count)
             
             it("identity matrix has correct dimensions") {
@@ -61,11 +78,13 @@ class MatrixSpec: QuickSpec {
             }
             
             it("identity matrix ones on diag") {
-                for (i, j) in zip(0..<count, 0..<count) {
-                    if i == j {
-                        expect(m4[i, j]).to(beCloseTo(1.0))
-                    } else {
-                        expect(m4[i, j]).to(beCloseTo(0.0))
+                for i in 0..<count {
+                    for j in 0..<count {
+                        if i == j {
+                            expect(m4[i, j]).to(beCloseTo(1.0))
+                        } else {
+                            expect(m4[i, j]).to(beCloseTo(0.0))
+                        }
                     }
                 }
             }
@@ -86,26 +105,31 @@ class MatrixSpec: QuickSpec {
             }
             
             it("diag matrix correct") {
-                for (i, j) in zip(0..<v1.count, 0..<v1.count) {
-                    if i == j {
-                        expect(m5[i, j]).to(beCloseTo(v1[i]))
-                        expect(m6[i, j]).to(beCloseTo(v1[i]))
-                        expect(m7[i, j]).to(beCloseTo(v1[i]))
-                    } else {
-                        expect(m5[i, j]).to(beCloseTo(0.0))
-                        expect(m6[i, j]).to(beCloseTo(0.0))
-                        expect(m7[i, j]).to(beCloseTo(0.0))
+                for i in 0..<v1.count {
+                    for j in 0..<v1.count {
+                        if i == j {
+                            expect(m5[i, j]).to(beCloseTo(v1[i]))
+                            expect(m6[i, j]).to(beCloseTo(v1[i]))
+                            expect(m7[i, j]).to(beCloseTo(v1[i]))
+                        } else {
+                            expect(m5[i, j]).to(beCloseTo(0.0))
+                            expect(m6[i, j]).to(beCloseTo(0.0))
+                            expect(m7[i, j]).to(beCloseTo(0.0))
+                        }
                     }
                 }
             }
             
             it("rand") {
-                let m8 = rand(1000, 1000)
-                expect(m8.rows) == 1000
-                expect(m8.cols) == 1000
-                _ = zip(0..<1000, 0..<1000).map { (i, j) in
-                    expect(m8[i, j]).to(beLessThan(1.0))
-                    expect(m8[i, j]).to(beGreaterThanOrEqualTo(0.0))
+                let size = 100
+                let m8 = rand(size, size)
+                expect(m8.rows) == size
+                expect(m8.cols) == size
+                for i in 0..<size {
+                    for j in 0..<size {
+                        expect(m8[i, j]).to(beLessThan(1.0))
+                        expect(m8[i, j]).to(beGreaterThanOrEqualTo(0.0))
+                    }
                 }
             }
             
@@ -552,6 +576,7 @@ class MatrixSpec: QuickSpec {
                                   [4.0, 2.0]])
                 expect(transpose(m1)) == res
                 expect(m1′) == res
+                expect(m1.T) == res
             }
             it("mtimes") {
                 let m1 = Matrix([[1.0, 3.0, 5.0],
@@ -654,6 +679,51 @@ class MatrixSpec: QuickSpec {
                 expect(u′ * u) == m1
                 let l = chol(m1, .Lower)
                 expect(l * l′) == m1
+            }
+            it("lstsq") {
+                // Setup
+                let a1 = Matrix([[1.44, -7.84, -4.39,  4.53],
+                                 [-9.96, -0.28, -3.24,  3.83],
+                                 [-7.55,  3.24,  6.27, -6.64],
+                                 [8.34,  8.09,  5.28,  2.06],
+                                 [7.08,  2.52,  0.74, -2.47],
+                                 [-5.45, -5.70, -1.19,  4.70]])
+                let b1 = Matrix([[8.58,  9.35],
+                                 [8.26, -4.43],
+                                 [8.48, -0.70],
+                                 [-5.28, -0.26],
+                                 [5.72, -7.36],
+                                 [8.93, -2.52]])
+                let c2 = Matrix([[-0.4506, 0.2497],
+                                 [-0.8491, -0.9020],
+                                 [0.7066, 0.6323],
+                                 [0.1288, 0.1351]])
+                let d2 = Matrix([[195.3616, 107.05746]])
+                
+                // Run function
+                let (c1, d1) = lstsqr(a1, b1)
+                
+                // Check solution matrix
+                expect(c1.rows) == c2.rows
+                expect(c1.cols) == c2.cols
+                for i in 0..<c1.rows {
+                    for j in 0..<c1.cols {
+                        let e1: Double = c1[i, j]
+                        let e2: Double = c2[i, j]
+                        expect(e1).to(beCloseTo(e2, within:0.001))
+                    }
+                }
+                
+                // Check residue matrix
+                expect(d1.rows) == d2.rows
+                expect(d1.cols) == d2.cols
+                for i in 0..<d1.rows {
+                    for j in 0..<d1.cols {
+                        let e1: Double = d1[i, j]
+                        let e2: Double = d2[i, j]
+                        expect(e1).to(beCloseTo(e2, within:0.001))
+                    }
+                }
             }
         }
         
@@ -793,6 +863,26 @@ class MatrixSpec: QuickSpec {
                 let res = Matrix([[1.0, 5.0, 6.0, 2.0],
                                   [3.0, 7.0, 8.0, 4.0]])
                 expect(insert(m1, cols: m2, at: 1)) == res
+            }
+            it("vstack") {
+                let m1 = Matrix([[1.0, 2.0, 3.0],
+                                 [4.0, 5.0, 6.0]])
+                let m2 = Matrix([[7.0, 8.0, 9.0],
+                                 [10.0, 11.0, 12.0]])
+                let res = Matrix([[1.0, 2.0, 3.0],
+                                  [4.0, 5.0, 6.0],
+                                  [7.0, 8.0, 9.0],
+                                  [10.0, 11.0, 12.0]])
+                expect(vstack([m1, m2])) == res
+            }
+            it("hstack") {
+                let m1 = Matrix([[1.0, 2.0, 3.0],
+                                 [4.0, 5.0, 6.0]])
+                let m2 = Matrix([[7.0, 8.0, 9.0],
+                                 [10.0, 11.0, 12.0]])
+                let res = Matrix([[1.0, 2.0, 3.0, 7.0, 8.0, 9.0],
+                                  [4.0, 5.0, 6.0, 10.0, 11.0, 12.0]])
+                expect(hstack([m1, m2])) == res
             }
         }
         

--- a/Sources/Matrix.swift
+++ b/Sources/Matrix.swift
@@ -21,6 +21,15 @@ public func zeros(_ rows: Int, _ cols: Int) -> Matrix {
     return Matrix(rows, cols, 0.0)
 }
 
+/// Create a matrix of zeros.
+///
+/// - Parameters:
+///    - m: Matrix
+/// - Returns: matrix of zeros with same size as input
+public func zeros(like m: Matrix) -> Matrix {
+    return zeros(m.rows, m.cols)
+}
+
 /// Create a matrix of ones.
 ///
 /// - Parameters:
@@ -30,6 +39,15 @@ public func zeros(_ rows: Int, _ cols: Int) -> Matrix {
 public func ones(_ rows: Int, _ cols: Int) -> Matrix {
     precondition(rows > 0 && cols > 0, "Matrix dimensions must be positive")
     return Matrix(rows, cols, 1.0)
+}
+
+/// Create a matrix of ones.
+///
+/// - Parameters:
+///    - m: Matrix
+/// - Returns: matrix of ones with same size as input
+public func ones(like m: Matrix) -> Matrix {
+    return ones(m.rows, m.cols)
 }
 
 /// Create a matrix of uniformly distributed on [0, 1) interval random values.
@@ -148,6 +166,13 @@ public class Matrix {
     /// Number of columns in Matrix.
     public var cols: Int {
         return _cols
+    }
+    
+    /// Transpose
+    public var T: Matrix {
+        get {
+            return transpose(self)
+        }
     }
     
     public init(_ r: Int, _ c: Int, _ value: Double = 0.0) {
@@ -432,6 +457,40 @@ public func toCols(_ A: Matrix, _ d: Dim) -> Matrix {
 }
 
 // MARK: - Matrix manipulation
+
+/// Vertically stack (top-to-bottom) rows in matrices.
+///
+/// Precondition: All matrices need the same number of columns.
+///
+/// - Parameters:
+///    - ma: [Matrix] (array of matrix)
+/// - Returns: new matrix by vertically stacking rows of input matrices
+public func vstack(_ ma: [Matrix]) -> Matrix {
+    precondition(ma.count > 0, "Must have at least 1 input matrix in array")
+    var m = ma[0]
+    for i in 1..<ma.count {
+        precondition(ma[i].cols == m.cols, "Number of cols must be equal")
+        m = append(m, rows: ma[i])
+    }
+    return m
+}
+
+/// Horizontally stack (left-to-right) columns in matrices.
+///
+/// Precondition: All matrices need the same number of rows.
+///
+/// - Parameters:
+///    - ma: [Matrix] (array of matrix)
+/// - Returns: new matrix by horizontally stacking columns of input matrices
+public func hstack(_ ma: [Matrix]) -> Matrix {
+    precondition(ma.count > 0, "Must have at least 1 input matrix in array")
+    var m = ma[0]
+    for i in 1..<ma.count {
+        precondition(ma[i].rows == m.rows, "Number of rows must be equal")
+        m = append(m, cols: ma[i])
+    }
+    return m
+}
 
 /// Insert row to matrix at specified position.
 ///

--- a/Sources/MatrixLeastSquare.swift
+++ b/Sources/MatrixLeastSquare.swift
@@ -1,0 +1,102 @@
+// MatrixLeastSquare.swift
+//
+// Created by Brett Larson on 9/10/20.
+// Copyright © 2020 Brett Larson. All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD license. See the LICENSE file for details.
+
+import Accelerate
+
+/// Compute the least squares solution to the overdetermined linear
+/// system A*X = B with full rank matrix A.
+///
+///    A precondition errors throw for mismatched matrix dimensions
+///    or if algorithm fails.
+///
+///    Requires M (rows of A) >= N (cols of A).
+///
+/// - Parameters:
+///     - A: MxN matrix
+///     - B: MxK matrix
+/// - Returns:
+///     - X: NxK solution matrix
+///     - R: 1xK residuals
+public func lstsqr(_ A: Matrix, _ B: Matrix) -> (X: Matrix, R: Matrix) {
+    precondition(A.rows >= A.cols, "A Matrix needs rows >= col")
+    precondition(A.rows == B.rows, "A and B Matrix rows must be equal")
+    
+    // Copies of input that can be modified.
+    // In the Intel example of dgels() I noticed the flat matrix has elements by rows
+    // and then columns thus the next transposes.  I tried changing TRANS to 'T'
+    // to eliminate the transpose but could not find the correct set of other changes
+    // to produce the correct solution.
+    let at = Matrix(A.T)
+    let bt = Matrix(B.T)
+    
+    var TRANS: Int8 = Int8(Array("N".utf8).first!)  // No transpose
+    var M = __CLPK_integer(A.rows)
+    var N = __CLPK_integer(A.cols)
+    var NRHS = __CLPK_integer(B.cols)
+    var LDA = M
+    var LDB = M
+    
+    var wkOpt = __CLPK_doublereal(0.0)
+    var lWork = __CLPK_integer(-1)
+    
+    var info: __CLPK_integer = 0
+ 
+    /* Query and allocate the optimal workspace */
+    dgels_(&TRANS, &M, &N, &NRHS, &(at.flat), &LDA, &(bt.flat), &LDB, &wkOpt, &lWork, &info);
+    
+    precondition(info == 0, "Error finding optimal lWork")
+    lWork = __CLPK_integer(wkOpt)
+    var work = Vector(repeating: 0.0, count: Int(lWork))
+    
+    /* Compute least square solution */
+    dgels_(&TRANS, &M, &N, &NRHS, &(at.flat), &LDA, &(bt.flat), &LDB, &work, &lWork, &info);
+    
+    precondition(info == 0, "Error")
+    
+    let X = bt.T[0..<Int(N), 0..<Int(NRHS)]
+    let R = zeros(1, Int(NRHS))
+    for i in 0..<Int(NRHS) {
+        var norm = 0.0
+        for j in 0..<Int(M-N) {
+            let x: Double = bt[i, Int(N)+j]
+            norm += x*x
+        }
+        R[0, i] = norm
+    }
+    
+    return (X, R)
+}
+
+/* Xcode 10.1
+ From </Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/Headers/clapack.h>
+ int dgels_(char *__trans, __CLPK_integer *__m, __CLPK_integer *__n,
+ __CLPK_integer *__nrhs, __CLPK_doublereal *__a, __CLPK_integer *__lda,
+ __CLPK_doublereal *__b, __CLPK_integer *__ldb,
+ __CLPK_doublereal *__work, __CLPK_integer *__lwork,
+ __CLPK_integer *__info)
+*/
+
+/*
+ Is there a problem defining Vector = [Double] = Array<Double> and
+ passing dereferenced address with & to LAPACK function?  See the
+ description for ContiguousArray<Element> at:
+    <https://developer.apple.com/documentation/swift/contiguousarray>
+ What I do not know is if "Double" is a class or @objc protocol.  Will
+ [Double] have contiguous data that LAPACK requires.
+ */
+
+/*
+ Reference Intel example of dgels() at:
+    <https://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/dgels_ex.c.htm>
+ This includes a test case with data.
+ */
+
+/*
+ Reference LAPACK documentation for dgels() at:
+    <http://www.netlib.org/lapack/double/dgels.f>
+ */

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -6,6 +6,13 @@
 // This software may be modified and distributed under the terms
 // of the BSD license. See the LICENSE file for details.
 
+precedencegroup ExponentiationPrecedence {
+    associativity: right
+    higherThan: MultiplicationPrecedence
+}
+
+infix operator .^ : ExponentiationPrecedence
+
 infix operator .* : MultiplicationPrecedence
 infix operator ./ : MultiplicationPrecedence
 infix operator ./. : MultiplicationPrecedence

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -6,12 +6,13 @@
 // This software may be modified and distributed under the terms
 // of the BSD license. See the LICENSE file for details.
 
+#if !compiler(>=5)
 precedencegroup ExponentiationPrecedence {
     associativity: right
     higherThan: MultiplicationPrecedence
 }
-
 infix operator .^ : ExponentiationPrecedence
+#endif
 
 infix operator .* : MultiplicationPrecedence
 infix operator ./ : MultiplicationPrecedence


### PR DESCRIPTION
My main purpose was to add matrix least squares lstsq().  I also added var T (alternate transpose operator), zeros(like:), ones(like:), vstack() and hstack().

I updated MatrixTests.swift for the new functions.  I altered the existing ones() and zeros() tests for non-rectangular matrices to better check for errors in rows and cols.  I also changed iterators where zip() was being used.  Only diagonal elements were getting tested.  After removing zip() the testing of rand(1000, 1000) became very slow so I reduced the size.

I updated Operators.swift adding ExponentiationPrecedence and operator .^.  It is still a mystery why I need this an others do not.  Different version of Swift?

I put the new lstsq() in its own file MatrixLeastSquares.swift.  I felt more comfortable doing this because some of my code comments include extra information that do not conform to other files.  Maybe it would be better to group this with the other linear algebra functions like inv(), svd(), etc?

I updated the Xcode project by adding MatrixLeastSquares.swift but I have not been able to get builds with Xcode to work.  I know my Xcode (10.1) is older than the version used to create the project because mine does not support Swift 5.  I have been able to build and test using the Swift Package Manager on the command line.  Someone who can build with Xcode should definitely verify that still works.

Note I have made some small changes to individual files I previously included in Issues.  Those earlier files should be ignored.