### PR TITLE
Add convolution operation

### DIFF
--- a/Example/Tests/MatrixTests.swift
+++ b/Example/Tests/MatrixTests.swift
@@ -895,6 +895,48 @@ class MatrixSpec: QuickSpec {
             }
         }
         
+        describe("matrix convolution") {
+            it("should return same matrix if convolving a matrix of 0's") {
+                let m1 = Matrix([[0,  0,  0,  0,  0],
+                                 [0,  0,  0,  0,  0],
+                                 [0,  0,  0,  0,  0],
+                                 [0,  0,  0,  0,  0]])
+                let kernel = Matrix([[1,  1,  1],
+                                     [1,  1,  1],
+                                     [1,  1,  1]])
+                let result = convolve(m1, kernel)
+                expect(result) == m1
+            }
+            it("should throw precondition failure if trying to convolve a matrix with a larger kernel") {
+                expect {
+                    let kernel = Matrix([[0,  0,  0,  0,  0],
+                                     [0,  0,  0,  0,  0],
+                                     [0,  0,  0,  0,  0],
+                                     [0,  0,  0,  0,  0]])
+                    let m1 = Matrix([[1,  1,  1],
+                                     [1,  1,  1],
+                                     [1,  1,  1]])
+                    _ = convolve(m1, kernel)
+                }.to(throwAssertion())
+            }
+            it("should convolve a matrix correctly") {
+                let m1 = Matrix([[1,  0,  0,  0,  0],
+                                 [0,  1,  0,  0,  0],
+                                 [0,  0,  1,  0,  0],
+                                 [0,  0,  0,  1,  0],
+                                 [0,  0,  0,  0,  1]])
+                let kernel = Matrix([[1,  1,  1],
+                                     [1,  1,  1],
+                                     [1,  1,  1]])
+                let result = convolve(m1, kernel)
+                expect(result) == Matrix([[0.0,  0.0,  0.0,  0.0,  0.0],
+                                          [0.0,  3.0,  2.0,  1.0,  0.0],
+                                          [0.0,  2.0,  3.0,  2.0,  0.0],
+                                          [0.0,  1.0,  2.0,  3.0,  0.0],
+                                          [0.0,  0.0,  0.0,  0.0,  0.0]])
+            }
+        }
+        
         describe("matrix slicing") {
             it("basic tests") {
                 let m1 = Matrix([[0,  1,  2,  3,  4],

--- a/Example/Tests/PerformanceTests.swift
+++ b/Example/Tests/PerformanceTests.swift
@@ -87,4 +87,11 @@ class PerformanceTests: XCTestCase {
             _ = maxi(self.a, .Column)
         }
     }
+    
+    func testConvolution() {
+        let k = rand(5, 7)
+        measure {
+            _ = convolve(self.a, k)
+        }
+    }
 }

--- a/Sources/MatrixAlgebra.swift
+++ b/Sources/MatrixAlgebra.swift
@@ -416,11 +416,11 @@ public func det(_ A: Matrix) -> Double {
 ///
 /// - Parameters:
 ///    - A: Matrix
-///    - K: Matrix (needs to be a square matrix)
+///    - K: Matrix (Needs to be smaller in dimension than A)
 /// - Returns: Matrix result of the convolution
-@available(iOS 13.0, macOS 15.0, *)
+@available(iOS 13.0, macOS 10.15, *)
 public func convolve(_ A: Matrix, _ K: Matrix) -> Matrix {
-    precondition(K._rows == K._cols, "K needs to be an NxN matrix")
+    precondition(A.rows > K.rows && A.cols > K.cols, "The kernel matrix needs to be smaller than the matrix it will convolve.")
     
     let result: [Double]
     

--- a/Sources/MatrixAlgebra.swift
+++ b/Sources/MatrixAlgebra.swift
@@ -411,3 +411,24 @@ public func det(_ A: Matrix) -> Double {
     
     return d
 }
+
+/// Return the result of convolving the given matrix with the provided kernel.
+///
+/// - Parameters:
+///    - A: Matrix
+///    - K: Matrix (needs to be a square matrix)
+/// - Returns: Matrix result of the convolution
+@available(iOS 13.0, macOS 15.0, *)
+public func convolve(_ A: Matrix, _ K: Matrix) -> Matrix {
+    precondition(K._rows == K._cols, "K needs to be an NxN matrix")
+    
+    let result: [Double]
+    
+    if K.rows == 3 {
+        result = Accelerate.vDSP.convolve(A.flat, rowCount: A._rows, columnCount: A._cols, with3x3Kernel: K.flat)
+    } else {
+        result = Accelerate.vDSP.convolve(A.flat, rowCount: A._rows, columnCount: A._cols, withKernel: K.flat, kernelRowCount: K._rows, kernelColumnCount: K._cols)
+    }
+    
+    return Matrix(A._rows, A._cols, result)
+}


### PR DESCRIPTION
Adds support for convolving matrices with NxM kernels (not necessarily square kernels) using the implementation described in https://developer.apple.com/documentation/accelerate/vdsp/2d_convolution